### PR TITLE
fix: update ground type gradient color

### DIFF
--- a/src/components/LeagueDisplay.tsx
+++ b/src/components/LeagueDisplay.tsx
@@ -206,7 +206,7 @@ function getTypeColor(type: string): string {
     Ice: 'from-cyan-400 to-cyan-500',
     Fighting: 'from-red-600 to-red-700',
     Poison: 'from-purple-500 to-purple-600',
-    Ground: 'from-yellow-600 to-brown-500',
+    Ground: 'from-yellow-600 to-yellow-700',
     Flying: 'from-indigo-400 to-sky-500',
     Psychic: 'from-pink-500 to-pink-600',
     Bug: 'from-lime-500 to-green-500',


### PR DESCRIPTION
## Summary
- fix ground type gradient with valid Tailwind color

## Testing
- `npm run lint` (fails: Unexpected any. Specify a different type)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68997658fee48321808c49342e880712