### PR TITLE
Add battle replay events with simple viewer

### DIFF
--- a/src/components/BattleReplay.tsx
+++ b/src/components/BattleReplay.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { BattleTurn } from '../types/league';
+
+interface BattleReplayProps {
+  turns: BattleTurn[];
+  musicUrl?: string;
+}
+
+export function BattleReplay({ turns, musicUrl }: BattleReplayProps) {
+  const [index, setIndex] = useState(0);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    if (musicUrl && audioRef.current) {
+      audioRef.current.play().catch(() => {});
+    }
+  }, [musicUrl]);
+
+  useEffect(() => {
+    if (index >= turns.length) return;
+    const timer = setTimeout(() => setIndex(i => i + 1), 1500);
+    return () => clearTimeout(timer);
+  }, [index, turns.length]);
+
+  if (index >= turns.length) {
+    return (
+      <div className="p-4">
+        {musicUrl && <audio ref={audioRef} src={musicUrl} loop />}
+        <p className="text-center">Battle replay finished.</p>
+      </div>
+    );
+  }
+
+  const turn = turns[index];
+
+  return (
+    <div className="p-4 space-y-2">
+      {musicUrl && <audio ref={audioRef} src={musicUrl} loop />}
+      <p className="font-bold">Turn {turn.turn}: {turn.attacker} used {turn.move}</p>
+      {turn.events.map((e, i) => (
+        <p key={i} className="ml-4 animate-pulse">
+          {e.type === 'damage'
+            ? `${turn.defender} took ${e.amount} damage!`
+            : `${turn.defender} ${e.status}`}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+BattleReplay.defaultProps = {
+  musicUrl: 'https://vgmsite.com/soundtracks/pokemon-red-blue-gameboy/kcdtdx28jq/3-34.%20Battle!%20(Vs%20Wild%20Pok%C3%A9mon).mp3'
+};
+

--- a/src/engine/league.ts
+++ b/src/engine/league.ts
@@ -279,7 +279,8 @@ export class LeagueEngine {
           [homePlayer.player_id]: battleResult.homeStats,
           [awayPlayer.player_id]: battleResult.awayStats
         },
-        seed_used: seed
+        seed_used: seed,
+        replay: battleResult.turns
       };
 
       results.push(result);

--- a/src/types/league.ts
+++ b/src/types/league.ts
@@ -51,6 +51,25 @@ export interface WeekSchedule {
   matchups: Matchup[];
 }
 
+export interface BattleEvent {
+  type: 'damage' | 'status';
+  amount?: number;
+  status?: string;
+}
+
+export interface BattleTurn {
+  turn: number;
+  attacker: string;
+  defender: string;
+  move: string;
+  damage: number;
+  critical: boolean;
+  effectiveness: number;
+  fainted: boolean;
+  missed?: boolean;
+  events: BattleEvent[];
+}
+
 export interface BattleResult {
   matchup_id: string;
   winner: string;
@@ -67,6 +86,7 @@ export interface BattleResult {
     };
   };
   seed_used: string;
+  replay: BattleTurn[];
 }
 
 export interface WeekResult {


### PR DESCRIPTION
## Summary
- track per-turn battle events including misses and status effects
- expose replay data in league results and add BattleReplay component with optional music

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a4189fbfc8321bf20034f9597aa43