### PR TITLE
Add stats dashboard and capture league metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
@@ -950,6 +952,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1781,6 +1789,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -3257,6 +3277,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { CommandPanel } from './components/CommandPanel';
 import { LeagueDisplay } from './components/LeagueDisplay';
 import { PokemonStats } from './components/PokemonStats';
+import { StatsDashboard } from './components/StatsDashboard';
 import { LeagueEngine } from './engine/league';
 import { Command, LeagueState, EngineResponse } from './types/league';
 import { Zap, Github } from 'lucide-react';
@@ -11,7 +12,7 @@ function App() {
   const [lastLogs, setLastLogs] = useState<string[]>([]);
   const [lastErrors, setLastErrors] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [view, setView] = useState<'league' | 'pokedex'>('league');
+  const [view, setView] = useState<'league' | 'pokedex' | 'stats'>('league');
 
   const engine = new LeagueEngine();
 
@@ -94,6 +95,12 @@ function App() {
                   className={`px-3 py-2 rounded-lg text-sm font-medium ${view === 'pokedex' ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}
                 >
                   Pokédex
+                </button>
+                <button
+                  onClick={() => setView('stats')}
+                  className={`px-3 py-2 rounded-lg text-sm font-medium ${view === 'stats' ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}
+                >
+                  Stats
                 </button>
               </nav>
               <a
@@ -181,8 +188,10 @@ function App() {
               </div>
             </div>
           </>
-        ) : (
+        ) : view === 'pokedex' ? (
           <PokemonStats />
+        ) : (
+          <StatsDashboard state={leagueState} />
         )}
       </main>
 

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { LeagueState } from '../types/league';
+import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+interface StatsDashboardProps {
+  state: LeagueState | null;
+}
+
+export function StatsDashboard({ state }: StatsDashboardProps) {
+  if (!state) {
+    return <div className="text-center p-4">No league data available.</div>;
+  }
+
+  const labels = state.players.map(p => p.name);
+  const wins = state.players.map(p => p.record.wins);
+  const losses = state.players.map(p => p.record.losses);
+  const kos = state.players.map(p => state.metrics.knockouts[p.player_id] || 0);
+
+  const recordData = {
+    labels,
+    datasets: [
+      {
+        label: 'Wins',
+        data: wins,
+        backgroundColor: 'rgba(34,197,94,0.5)'
+      },
+      {
+        label: 'Losses',
+        data: losses,
+        backgroundColor: 'rgba(239,68,68,0.5)'
+      }
+    ]
+  };
+
+  const koData = {
+    labels,
+    datasets: [
+      {
+        label: 'Knockouts',
+        data: kos,
+        backgroundColor: 'rgba(59,130,246,0.5)'
+      }
+    ]
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">Player Records</h2>
+        <Bar data={recordData} />
+      </div>
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">Total Knockouts</h2>
+        <Bar data={koData} />
+      </div>
+    </div>
+  );
+}

--- a/src/engine/league.ts
+++ b/src/engine/league.ts
@@ -123,6 +123,13 @@ export class LeagueEngine {
       },
       history: {
         weeks: []
+      },
+      metrics: {
+        total_battles: 0,
+        knockouts: args.players.reduce((acc: any, p: any) => {
+          acc[p.player_id] = 0;
+          return acc;
+        }, {})
       }
     };
 
@@ -265,6 +272,13 @@ export class LeagueEngine {
       // Update records
       winner.record.wins++;
       loser.record.losses++;
+
+      // Update league metrics
+      state.metrics.total_battles++;
+      state.metrics.knockouts[homePlayer.player_id] =
+        (state.metrics.knockouts[homePlayer.player_id] || 0) + battleResult.homeKOs;
+      state.metrics.knockouts[awayPlayer.player_id] =
+        (state.metrics.knockouts[awayPlayer.player_id] || 0) + battleResult.awayKOs;
 
       const result = {
         matchup_id: matchup.matchup_id,

--- a/src/types/league.ts
+++ b/src/types/league.ts
@@ -113,6 +113,10 @@ export interface LeagueState {
   history: {
     weeks: WeekResult[];
   };
+  metrics: {
+    total_battles: number;
+    knockouts: { [player_id: string]: number };
+  };
 }
 
 export interface Command {


### PR DESCRIPTION
## Summary
- track total battles and per-player knockouts in league state
- add stats dashboard with chart.js visualizations
- expose dashboard via new "Stats" view in app navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a41a083f48321954a9c1785399156